### PR TITLE
accept %o and %O (as %j) - special case functions and strings to %o (or %j)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "quick-format",
-  "version": "2.0.6",
+  "name": "quick-format-unescaped",
+  "version": "1.0.0",
   "description": "Solves a problem with util.format",
   "main": "index.js",
   "directories": {

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,11 @@
-# quick format
+# quick format unescaped
 
 Solves a problem with util.format
+
+## unescaped ?
+
+Sometimes you want to embed the results of quick-format into another string, 
+and then escape the whole string. 
 
 ## usage
 


### PR DESCRIPTION
this mainly improves `pino-debug` output, since `debug` supports %o and libraries like express make extensive use of it

changes have no speed hit (node 6 checked)

```
change:

quickLowres*100000: 268.242ms
quick*100000: 293.952ms
quickLowres*100000: 260.914ms
quick*100000: 287.245ms


master: 

quickLowres*100000: 265.964ms
quick*100000: 301.656ms
quickLowres*100000: 256.617ms
quick*100000: 298.928ms
```