### PR TITLE
%o %O function/strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var safeStringify = require('fast-safe-stringify')
 function tryStringify (o) {
   try { return JSON.stringify(o) } catch(e) { return '"[Circular]"' }
 }
+
 module.exports = function format(args, opts) {
   var ss = (opts && opts.lowres) ? tryStringify : safeStringify
   var f = args[0]
@@ -33,12 +34,25 @@ module.exports = function format(args, opts) {
           str += Number(args[a])
           lastPos = i = i + 2
           break
+        case 79: // 'O'
+        case 111: // 'o'
         case 106: // 'j'
           if (a >= argLen)
             break
           if (lastPos < i)
             str += f.slice(lastPos, i)
           if (args[a] === undefined) break
+          var type = typeof args[a]
+          if (type === 'string') {
+            str += '\'' + args[a] + '\''
+            lastPos = i = i + 2
+            break
+          }
+          if (type === 'function') {
+            str += args[a].name || '<anonymous>'
+            lastPos = i = i + 2
+            break
+          }
           x = JSON.stringify(ss(args[a]))
           str += x.substr(1, x.length - 2)
           lastPos = i = i + 2


### PR DESCRIPTION
this mainly improves `pino-debug` output, since `debug` supports %o and libraries like express make extensive use of it

changes have no speed hit (node 6 checked)

```
change:

quickLowres*100000: 268.242ms
quick*100000: 293.952ms
quickLowres*100000: 260.914ms
quick*100000: 287.245ms


master: 

quickLowres*100000: 265.964ms
quick*100000: 301.656ms
quickLowres*100000: 256.617ms
quick*100000: 298.928ms
```